### PR TITLE
Remove previously chained models from choices & fix circular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "djangoql-completion",
   "description": "DjangoQL completion widget",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "license": "MIT",
   "homepage": "https://github.com/ivelum/djangoql-completion",
   "author": "Denis Stebunov (https://github.com/stebunovd)",

--- a/src/index.js
+++ b/src/index.js
@@ -859,7 +859,7 @@ DjangoQL.prototype = {
     }
   },
 
-  setCurrentModel: function (model) {
+  setCurrentModel(model) {
     if (this.models[model]) {
       this.currentModel = model;
       this.modelStack = [model];
@@ -917,16 +917,16 @@ DjangoQL.prototype = {
     }
     // Save last entered value
     this.previousInputValue = input.value;
- 
+
     this.prefix = context.prefix;
     const model = this.models[context.model];
     const field = context.field && model[context.field];
 
-    const modelStack = this.modelStack;
+    const { modelStack } = this;
     switch (context.scope) {
       case 'field':
-        this.suggestions = Object.keys(model).filter(function (f) {
-          const relation = model[f].relation;
+        this.suggestions = Object.keys(model).filter((f) => {
+          const { relation } = model[f];
           if ((model[f].type === 'relation')
             // Check that the model from a field relation wasn't in the stack
             && (modelStack.indexOf(relation) !== -1)
@@ -934,8 +934,8 @@ DjangoQL.prototype = {
             // E.g. an "author" can have the "authors_in_genre" relation
             && (modelStack.slice(-1)[0] !== relation)
           ) {
-              return false;
-            }
+            return false;
+          }
           return true;
         }).map((f) => (
           suggestion(f, '', model[f].type === 'relation' ? '.' : ' ')

--- a/tests/DjangoQL.test.js
+++ b/tests/DjangoQL.test.js
@@ -204,7 +204,7 @@ describe('test DjangoQL completion', () => {
           modelStack: ['core.book', 'auth.user'],
         });
       expect(djangoQL.resolveName('author.first_name'))
-        .toStrictEqual({ 
+        .toStrictEqual({
           model: 'auth.user',
           field: 'first_name',
           modelStack: ['core.book', 'auth.user'],
@@ -475,7 +475,6 @@ describe('test DjangoQL completion', () => {
           text: 'author',
         }]),
       );
-
 
       djangoQL.currentModel = 'auth.group';
       djangoQL.textarea.value = 'user.';

--- a/tests/DjangoQL.test.js
+++ b/tests/DjangoQL.test.js
@@ -403,4 +403,57 @@ describe('test DjangoQL completion', () => {
       });
     });
   });
+
+  describe('.generateSuggestions()', () => {
+    it('should not have circular deps', () => {
+      djangoQL.textarea.value = 'author.';
+      djangoQL.generateSuggestions();
+      // "book.author.book" sholdn't be suggested
+      expect(djangoQL.suggestions).toEqual(
+        expect.not.arrayContaining([{
+          snippetAfter: ".",
+          snippetBefore: "",
+          suggestionText: "book",
+          text: "book",
+        }])
+      );
+      
+      // Change model and test in reverse side
+      djangoQL.setCurrentModel('core.author');
+      djangoQL.textarea.value = 'book.';
+      djangoQL.generateSuggestions();
+      expect(djangoQL.suggestions).toEqual(
+        expect.not.arrayContaining([{
+          snippetAfter: ".",
+          snippetBefore: "",
+          suggestionText: "author",
+          text: "author",
+        }])
+      );
+
+      // Add words one be one to build the Model Stack
+      djangoQL.setCurrentModel('auth.group');
+      djangoQL.textarea.value = 'user.';
+      djangoQL.generateSuggestions();
+      expect(djangoQL.suggestions).toEqual(
+        expect.arrayContaining([{
+          snippetAfter: ".",
+          snippetBefore: "",
+          suggestionText: "book",
+          text: "book",
+        }])
+      );
+      djangoQL.textarea.value = 'user.book.';
+      djangoQL.generateSuggestions();
+      // "User" model is already in the Model Stack
+      expect(djangoQL.suggestions).toEqual(
+        expect.not.arrayContaining([{
+          snippetAfter: ".",
+          snippetBefore: "",
+          suggestionText: "author",
+          text: "author",
+        }])
+      );
+    });
+  });
 });

--- a/tests/DjangoQL.test.js
+++ b/tests/DjangoQL.test.js
@@ -192,25 +192,67 @@ describe('test DjangoQL completion', () => {
   describe('.resolveName()', () => {
     it('should properly resolve known names', () => {
       expect(djangoQL.resolveName('price'))
-        .toStrictEqual({ model: 'core.book', field: 'price' });
+        .toStrictEqual({
+          model: 'core.book',
+          field: 'price',
+          modelStack: ['core.book'],
+        });
       expect(djangoQL.resolveName('author'))
-        .toStrictEqual({ model: 'auth.user', field: null });
+        .toStrictEqual({
+          model: 'auth.user',
+          field: null,
+          modelStack: ['core.book', 'auth.user'],
+        });
       expect(djangoQL.resolveName('author.first_name'))
-        .toStrictEqual({ model: 'auth.user', field: 'first_name' });
+        .toStrictEqual({ 
+          model: 'auth.user',
+          field: 'first_name',
+          modelStack: ['core.book', 'auth.user'],
+        });
       expect(djangoQL.resolveName('author.groups'))
-        .toStrictEqual({ model: 'auth.group', field: null });
+        .toStrictEqual({
+          model: 'auth.group',
+          field: null,
+          modelStack: ['core.book', 'auth.user', 'auth.group'],
+        });
       expect(djangoQL.resolveName('author.groups.id'))
-        .toStrictEqual({ model: 'auth.group', field: 'id' });
+        .toStrictEqual({
+          model: 'auth.group',
+          field: 'id',
+          modelStack: ['core.book', 'auth.user', 'auth.group'],
+        });
       expect(djangoQL.resolveName('author.groups.user'))
-        .toStrictEqual({ model: 'auth.user', field: null });
+        .toStrictEqual({
+          model: 'auth.user',
+          field: null,
+          modelStack: ['core.book', 'auth.user', 'auth.group', 'auth.user'],
+        });
       expect(djangoQL.resolveName('author.groups.user.email'))
-        .toStrictEqual({ model: 'auth.user', field: 'email' });
+        .toStrictEqual({
+          model: 'auth.user',
+          field: 'email',
+          modelStack: ['core.book', 'auth.user', 'auth.group', 'auth.user'],
+        });
     });
     it('should return nulls for unknown names', () => {
-      ['gav', 'author.gav', 'author.groups.gav'].forEach((name) => {
-        expect(djangoQL.resolveName(name))
-          .toStrictEqual({ model: null, field: null });
-      });
+      expect(djangoQL.resolveName('gav'))
+        .toStrictEqual({
+          model: null,
+          field: null,
+          modelStack: ['core.book'],
+        });
+      expect(djangoQL.resolveName('author.gav'))
+        .toStrictEqual({
+          model: null,
+          field: null,
+          modelStack: ['core.book', 'auth.user'],
+        });
+      expect(djangoQL.resolveName('author.groups.gav'))
+        .toStrictEqual({
+          model: null,
+          field: null,
+          modelStack: ['core.book', 'auth.user', 'auth.group'],
+        });
     });
   });
 
@@ -422,7 +464,7 @@ describe('test DjangoQL completion', () => {
       );
 
       // Change model and test in reverse side
-      djangoQL.setCurrentModel('core.author');
+      djangoQL.currentModel = 'auth.user';
       djangoQL.textarea.value = 'book.';
       djangoQL.generateSuggestions();
       expect(djangoQL.suggestions).toStrictEqual(
@@ -434,8 +476,8 @@ describe('test DjangoQL completion', () => {
         }]),
       );
 
-      // Add words one be one to build the Model Stack
-      djangoQL.setCurrentModel('auth.group');
+
+      djangoQL.currentModel = 'auth.group';
       djangoQL.textarea.value = 'user.';
       djangoQL.generateSuggestions();
       expect(djangoQL.suggestions).toStrictEqual(

--- a/tests/DjangoQL.test.js
+++ b/tests/DjangoQL.test.js
@@ -384,6 +384,9 @@ describe('test DjangoQL completion', () => {
       examples.forEach((e) => {
         const result = djangoQL.getContext(...e.args);
         delete result.currentFullToken; // it's not relevant in this case
+        // Model Stack properly builds only for continiously interaction
+        // with textarea for now
+        delete result.modelStack;
         expect(result).toStrictEqual(e.result);
       });
     });

--- a/tests/DjangoQL.test.js
+++ b/tests/DjangoQL.test.js
@@ -409,50 +409,50 @@ describe('test DjangoQL completion', () => {
       djangoQL.textarea.value = 'author.';
       djangoQL.generateSuggestions();
       // "book.author.book" sholdn't be suggested
-      expect(djangoQL.suggestions).toEqual(
+      expect(djangoQL.suggestions).toStrictEqual(
         expect.not.arrayContaining([{
-          snippetAfter: ".",
-          snippetBefore: "",
-          suggestionText: "book",
-          text: "book",
-        }])
+          snippetAfter: '.',
+          snippetBefore: '',
+          suggestionText: 'book',
+          text: 'book',
+        }]),
       );
-      
+
       // Change model and test in reverse side
       djangoQL.setCurrentModel('core.author');
       djangoQL.textarea.value = 'book.';
       djangoQL.generateSuggestions();
-      expect(djangoQL.suggestions).toEqual(
+      expect(djangoQL.suggestions).toStrictEqual(
         expect.not.arrayContaining([{
-          snippetAfter: ".",
-          snippetBefore: "",
-          suggestionText: "author",
-          text: "author",
-        }])
+          snippetAfter: '.',
+          snippetBefore: '',
+          suggestionText: 'author',
+          text: 'author',
+        }]),
       );
 
       // Add words one be one to build the Model Stack
       djangoQL.setCurrentModel('auth.group');
       djangoQL.textarea.value = 'user.';
       djangoQL.generateSuggestions();
-      expect(djangoQL.suggestions).toEqual(
+      expect(djangoQL.suggestions).toStrictEqual(
         expect.arrayContaining([{
-          snippetAfter: ".",
-          snippetBefore: "",
-          suggestionText: "book",
-          text: "book",
-        }])
+          snippetAfter: '.',
+          snippetBefore: '',
+          suggestionText: 'book',
+          text: 'book',
+        }]),
       );
       djangoQL.textarea.value = 'user.book.';
       djangoQL.generateSuggestions();
       // "User" model is already in the Model Stack
-      expect(djangoQL.suggestions).toEqual(
+      expect(djangoQL.suggestions).toStrictEqual(
         expect.not.arrayContaining([{
-          snippetAfter: ".",
-          snippetBefore: "",
-          suggestionText: "author",
-          text: "author",
-        }])
+          snippetAfter: '.',
+          snippetBefore: '',
+          suggestionText: 'author',
+          text: 'author',
+        }]),
       );
     });
   });


### PR DESCRIPTION
Hi there,

I've prepared the fix for removing chained models from choices and fixing circular dependencies.

The condition on the backend side was applied to avoid circular dependencies.
https://github.com/ivelum/djangoql/blob/master/djangoql/schema.py#L372

These changes appeared after this pull request https://github.com/ivelum/djangoql/commit/3e2ca75815f5d9cb69a3a5ab8a5ee5d90d172ef4#diff-f67209e7ff98d18b4b4304fff7b422244b54a19233e58fa37e8bd2cf29cadaaeR355

Pay attention, that this pull request can be merged https://github.com/ivelum/djangoql/pull/77 after applying changes from my pull request.

Thanks,
Denis